### PR TITLE
Fix/nodejs error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Added the ability to deploy Angular apps using [the new application-builder](https://angular.dev/tools/cli/esbuild). (#6480)
 - Fixed an issue where `--non-interactive` flag is not respected in Firestore indexes deploys. (#6539)
 - Fixed an issue where `login:use` would not work outside of a Firebase project directory. (#6526)
+- Add Node 20 to error messages when using an unsupported Node version

--- a/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
+++ b/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
@@ -19,6 +19,8 @@ const ENGINE_RUNTIMES: Record<number, runtimes.Runtime | runtimes.DeprecatedRunt
   20: "nodejs20",
 };
 
+const VALID_NODE_VERSIONS: string = "10|12|14|16|18|20";
+
 const ENGINE_RUNTIMES_NAMES = Object.values(ENGINE_RUNTIMES);
 
 export const RUNTIME_NOT_SET =
@@ -28,12 +30,12 @@ export const RUNTIME_NOT_SET =
 
 export const UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG = clc.bold(
   `functions.runtime value is unsupported. ` +
-    `Valid choices are: ${clc.bold("nodejs{10|12|14|16|18}")}.`
+    `Valid choices are: ${clc.bold(`nodejs{${VALID_NODE_VERSIONS}}`)}.`
 );
 
 export const UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG = clc.bold(
   `package.json in functions directory has an engines field which is unsupported. ` +
-    `Valid choices are: ${clc.bold('{"node": 10|12|14|16|18}')}`
+    `Valid choices are: ${clc.bold(`{"node": ${VALID_NODE_VERSIONS}}`)}`
 );
 
 export const DEPRECATED_NODE_VERSION_INFO =

--- a/src/test/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.spec.ts
@@ -49,7 +49,22 @@ describe("getRuntimeChoice", () => {
       expect(runtime.getRuntimeChoice("path/to/source", "nodejs16")).to.equal("nodejs16");
     });
 
+    it("should return node 18 if runtime field is set to node 18", () => {
+      expect(runtime.getRuntimeChoice("path/to/source", "nodejs18")).to.equal("nodejs18");
+    });
+
+    it("should return node 20 if runtime field is set to node 20", () => {
+      expect(runtime.getRuntimeChoice("path/to/source", "nodejs20")).to.equal("nodejs20");
+    });
+
     it("should throw error if unsupported node version set", () => {
+      expect(() => runtime.getRuntimeChoice("path/to/source", "nodejs11")).to.throw(
+        FirebaseError,
+        runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
+      );
+    });
+
+    it("should throw error if runtime field is set to node 22", () => {
       expect(() => runtime.getRuntimeChoice("path/to/source", "nodejs11")).to.throw(
         FirebaseError,
         runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
@@ -98,6 +113,18 @@ describe("getRuntimeChoice", () => {
       expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs16");
     });
 
+    it("should return node 18 if engines field is set to node 18", () => {
+      cjsonStub.returns({ engines: { node: "18" } });
+
+      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs18");
+    });
+
+    it("should return node 20 if engines field is set to node 20", () => {
+      cjsonStub.returns({ engines: { node: "20" } });
+
+      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs20");
+    });
+
     it("should print warning when firebase-functions version is below 2.0.0", () => {
       cjsonStub.returns({ engines: { node: "16" } });
 
@@ -113,6 +140,16 @@ describe("getRuntimeChoice", () => {
     it("should throw error if unsupported node version set", () => {
       cjsonStub.returns({
         engines: { node: "11" },
+      });
+      expect(() => runtime.getRuntimeChoice("path/to/source", "")).to.throw(
+        FirebaseError,
+        runtime.UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG
+      );
+    });
+
+    it("should throw error if engines field is set to node 22", () => {
+      cjsonStub.returns({
+        engines: { node: "22" },
       });
       expect(() => runtime.getRuntimeChoice("path/to/source", "")).to.throw(
         FirebaseError,


### PR DESCRIPTION
### Description

I was trying to deploy my Cloud Functions using a newer Node version and I got this error:
<img width="1240" alt="Screenshot 2023-12-01 at 11 20 49" src="https://github.com/firebase/firebase-tools/assets/19170641/8179305c-7eeb-4ece-8484-3b1a9191532c">

I knew for a fact that Node 20 was supported with Cloud Functions, so this was confusing. After looking into the code I found out that the error message is wrong, but Node 20 is actually supported.

### Scenarios Tested

Manually provided incorrect Node versions and the expected error message shows (including Node 20). Does not affect anything when providing correct Node versions.

### Follow-up changes

I see there is a lot of repetition in the code regarding legacy/supported/unsupported Node versions. Attaching screenshots.

**src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts**
<img width="858" alt="Screenshot 2023-12-01 at 11 27 15" src="https://github.com/firebase/firebase-tools/assets/19170641/bf0b84fb-ee2e-4695-ad56-35b97d273ccd">

**src/deploy/functions/runtimes/index.ts**
<img width="657" alt="Screenshot 2023-12-01 at 11 27 33" src="https://github.com/firebase/firebase-tools/assets/19170641/e6b62d89-0da2-45f6-8e93-f44475864b17">
<img width="764" alt="Screenshot 2023-12-01 at 11 27 38" src="https://github.com/firebase/firebase-tools/assets/19170641/4fb93069-a968-408f-bb43-dbc287d16e78">
<img width="533" alt="Screenshot 2023-12-01 at 11 27 26" src="https://github.com/firebase/firebase-tools/assets/19170641/e835e7b7-09fb-40e9-8b95-9eef27acf18c">

Happy to clean it up in a follow-up PR if you think it's valuable.